### PR TITLE
Example: Auto generate wrappers to avoid UB

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -178,6 +178,8 @@ fn main() {
     }
 
     c.compile(&format!("mozjpeg{}", abi));
+
+    generate_ffi_mod();
 }
 
 fn nasm_supported() -> bool {
@@ -262,4 +264,324 @@ fn build_nasm(root: &Path, vendor_dir: &Path, out_dir: &Path, target_arch: &str,
         }
     }
     n.compile_objects()
+}
+
+fn generate_ffi_mod() {
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("outdir"));
+    let src_dir = env::current_dir().expect("failed to get current directory");
+
+    eprintln!("OUT_DIR={}", out_dir.display());
+    eprintln!("SRC_DIR={}", src_dir.display());
+    let ffi_input = src_dir.join("src").join("ffi.rs");
+    let ffi_src = std::fs::read_to_string(ffi_input.clone()).expect("failed to read src/ffi.rs");
+    println!("{}", format!("cargo:rerun-if-changed={}", ffi_input.display()));
+
+    // Parse src/ffi.rs generating Rust and C wrappers
+    let decls = parse_decls(&ffi_src);
+    let rust_wrapper = generate_rust_wrappers(&decls);
+    let cxx_wrapper = generate_cxx_wrappers(&decls);
+
+    let rust_output = &format!("{}", rust_wrapper.join(""));
+    let rust_ffi_out = out_dir.join("ffi.rs");
+    std::fs::write(rust_ffi_out, rust_output).unwrap();
+
+    let cxx_output = &format!("{}{}", cxx_header(), cxx_wrapper.join(""));
+    let cxx_out = out_dir.join("mozjpeg_cxx_wrapper.cpp");
+    std::fs::write(cxx_out.clone(), cxx_output).unwrap();
+
+    let mozjpeg_include = src_dir.join("vendor");
+    let config_dir = out_dir.join("include");
+    cc::Build::new()
+        .file(cxx_out)
+        .flag("-Wno-return-type-c-linkage")
+        .include(mozjpeg_include)
+        .include(config_dir)
+        .cpp(true)
+        .compile("mozjpeg_cxx_wrapper");
+}
+
+#[derive(Debug)]
+struct Decl {
+    name: String,
+    is_pub: bool,
+    doc: Vec<String>,
+    attrs: Vec<String>,
+    args: Vec<(String, String)>,
+    ret_ty: Option<String>,
+    lifetime: Option<String>
+}
+
+fn parse_decls(ffi_src: &str) -> Vec<Decl> {
+    // Remove extern "C" { ... } block
+    let input = {
+        let (start_idx, end_idx) = (ffi_src.find('{').unwrap(), ffi_src.rfind('}').unwrap());
+        &ffi_src[start_idx+1..end_idx]
+    };
+    // Remove all whitespace and split `;` to get an Iterator over the decls:
+    let input: Vec<String> = input.split(';').map(ToString::to_string).collect();
+
+    // Parse each declaration and generate wrappers
+    let mut decls = Vec::new();
+    for decl in &input {
+        if decl.trim().is_empty() { continue; }
+        let (doc, attrs) = {
+            let mut doc = Vec::new();
+            let mut attrs = Vec::new();
+            for line in decl.lines() {
+                let line = line.trim();
+                if line.starts_with("///") {
+                    doc.push(line.to_string());
+                } else if line.starts_with("#") {
+                    attrs.push(line.to_string());
+                } else {
+                    break;
+                }
+            }
+            (doc, attrs)
+        };
+        let decl = decl.replace(|c| c == '\n' || c == '\r', "");
+        let is_pub = decl.find("pub fn").is_some();
+        let start_idx = decl.find("fn ").unwrap();
+        let decl = &decl[start_idx..];
+        let name = {
+                let end_idx0 = decl.find('<');
+                let end_idx1 = decl.find('(');
+                let end_idx = match (end_idx0, end_idx1) {
+                    (Some(v), None) => v,
+                    (None, Some(v)) => v,
+                    (Some(i), Some(j)) => i.min(j),
+                    (None, None) => panic!(),
+                };
+                decl["fn ".len()..end_idx].to_string()
+        };
+        match name.as_str() {
+            | "jpeg_float_add_quant_table"
+                | "jpeg_calc_jpeg_dimensions"
+                | "jsimd_fdct_ifast"
+                | "jsimd_can_rgb_ycc"
+                | "jsimd_can_fdct_ifas"
+                => continue,
+
+            _ => (),
+        }
+        let lifetime = decl.find('<').map(|v| decl[v+1..decl.find('>').unwrap()].to_string());
+        let args: Vec<(String,String)> = decl.find('(')
+                .map(|v| &decl[v+1..decl.find(')').unwrap()]).unwrap().split(',')
+            .filter(|s| !s.trim().is_empty())
+            .map(|s|{
+                let mut s = s.split(':');
+                let arg_name = s.next().unwrap();
+                let ty_name = s.next().unwrap();
+                (arg_name.trim().to_string(), ty_name.trim().to_string())
+            }).collect();
+        let ret_ty = decl.rfind("->").map(|s| decl[s+2..].trim().to_string());
+        decls.push( Decl { name, is_pub, doc, attrs, args, ret_ty, lifetime });
+    }
+
+    decls
+}
+
+fn generate_cxx_wrappers(decls: &Vec<Decl>) -> Vec<String> {
+    decls.iter().map(|d| generate_cxx_wrapper(d)).collect()
+}
+
+fn generate_rust_wrappers(decls: &Vec<Decl>) -> Vec<String> {
+    decls.iter().map(|d| generate_rust_wrapper(d)).collect()
+}
+
+fn generate_rust_wrapper(decl: &Decl) -> String {
+    format!(r#"
+    {doc}
+    {attrs}
+    {pub_vis} unsafe fn {wrapper_name}{lifetime}({params}) -> {ret_ty} {{
+        extern "C" {{
+            fn {c_wrapper_name}{lifetime}({params}) -> WrapperResult<{ret_ty}>;
+        }}
+        let result = {c_wrapper_name}({arg_ids});
+        if result.discriminant == 0 {{
+           result.value.value
+        }} else {{
+           let WrapperError{{ buf, len, cap }}: WrapperError = result.value.error;
+           panic!(String::from_raw_parts(buf, len, cap))
+        }}
+    }}
+    "#,
+            doc = decl.doc.join("\n"),
+            attrs = decl.attrs.join("\n"),
+            pub_vis = if decl.is_pub { "pub" } else { "" },
+            wrapper_name = decl.name,
+            lifetime = decl.lifetime.clone().map(|l| format!("<{}>", l)).unwrap_or_default(),
+            params = decl.args.iter().map(|(id, ty)| format!("{}: {}", id, ty)).collect::<Vec<_>>().join(","),
+            c_wrapper_name = format!("{}_cxx", decl.name),
+            arg_ids = decl.args.iter().map(|(id, _)| id.clone()).collect::<Vec<_>>().join(","),
+            ret_ty = decl.ret_ty.clone().unwrap_or("()".to_string()),
+    )
+}
+
+fn generate_cxx_wrapper(decl: &Decl) -> String {
+    let ret_ty = decl.ret_ty.clone().map(|t| c_type(&t)).unwrap_or("void".to_string());
+    let arg_ids = decl.args.iter().map(|(id, _)| id.clone()).collect::<Vec<_>>().join(",");
+    let value_return = if decl.ret_ty.is_some() {
+        format!(
+            "return WrapperResult<{ret_ty}>::value({wrapper_name}({arg_ids}));",
+            ret_ty = ret_ty,
+            wrapper_name = decl.name,
+            arg_ids = arg_ids
+        )
+    } else {
+        format!(
+            "{wrapper_name}({arg_ids}); return WrapperResult<{ret_ty}>::value();",
+            ret_ty = ret_ty,
+            wrapper_name = decl.name,
+            arg_ids = arg_ids
+        )
+    };
+    format!(r#"
+    extern "C" WrapperResult<{ret_ty}> {c_wrapper_name}({params}) {{
+        try {{
+             {value_return}
+        }} catch(mozjpeg_rust_wrapper_exception const& e) {{
+             return WrapperResult<{ret_ty}>::error(e.error);
+        }}
+    }}
+    "#,
+            ret_ty = ret_ty,
+            c_wrapper_name = format!("{}_cxx", decl.name),
+            params = decl.args.iter().map(|(id, ty)| c_param(&id, &ty)).collect::<Vec<_>>().join(","),
+            value_return = value_return
+    )
+}
+
+fn is_c_ptr(v: &str) -> bool { v.starts_with("&") || v.starts_with("*") }
+
+fn rust_ptr_to_c_ptr(x: &str) -> String { // ADAPTED FROM CTEST
+    let mut ty = String::new();
+    for x in x.split('\'') { 
+        if ty.is_empty() {
+            ty += x;
+        } else {
+            if let Some(i) = x.find(char::is_whitespace) {
+                ty += &x[i..];
+            } else {
+                break;
+            }
+        }
+    }
+    let mut mutability = Vec::new();
+    let ptr_count = ty.chars().filter(|c| is_c_ptr(&c.to_string())).count();
+    let mut ty: &str = &ty[1..];
+    for _ in 0..ptr_count {
+        if let Some(idx) = ty.find(|c: char| is_c_ptr(&c.to_string())) {
+            if let Some(mut_idx) = ty[0..idx].find("mut") {
+                mutability.push(true);
+                ty = &ty[mut_idx+5..];
+            } else {
+                mutability.push(false);
+                if let Some(const_idx) = ty[0..idx].find("const") {
+                    ty = &ty[const_idx+6..];
+                } else {
+                    ty = &ty[idx+1..];
+                }
+            }
+        } else {
+            if let Some(mut_idx) = ty[0..].find("mut") {
+                mutability.push(true);
+                ty = &ty[mut_idx+4..];
+            } else {
+                mutability.push(false);
+                if ty.contains("const") {
+                    ty = &ty[6..];
+                }
+            }
+        }
+    }
+    let c_ty = c_type(ty);
+    let mutability: Vec<&'static str> = mutability.iter().rev().map(|&m| if m { "*" } else { "const *" }).collect();
+    let result = format!("{} {}", c_ty, mutability.join(" "));
+    result
+}
+
+fn c_type(ty: &str) -> String {
+    match ty {
+        v if is_c_ptr(v) => { rust_ptr_to_c_ptr(v) }
+        "c_void" => "void".to_string(),
+        "boolean" => "boolean".to_string(),
+        "u8" => "unsigned char".to_string(),
+        "c_int" => "int".to_string(),
+        "f32" => "float".to_string(),
+        "c_ulong" => "unsigned long".to_string(),
+        "c_uint" => "unsigned int".to_string(),
+        "usize" => "uintptr_t".to_string(),
+        "JSAMPARRAY_MUT" => "JSAMPARRAY".to_string(),
+        "JSAMPIMAGE_MUT" => "JSAMPIMAGE".to_string(),
+        v => v.to_string(),
+    }
+}
+
+fn c_param(id: &str, ty: &str) -> String {
+    match ty {
+        v => format!("{} {}", c_type(ty), id),
+    }
+}
+
+fn cxx_header() -> String {
+r#"
+    #include <jinclude.h>
+    #include <jpeglib.h>
+    #include <jconfig.h>
+    #include <jconfigint.h>
+    #include <stdexcept>
+
+    struct WrapperError {
+        char* buf;
+        uintptr_t len;
+        uintptr_t cap;
+    };
+
+    struct mozjpeg_rust_wrapper_exception: std::runtime_error {
+        WrapperError error;
+    };
+
+    template <typename T>
+    union WrapperData {
+        T value;
+        WrapperError error;
+        WrapperData(T v) : value(v) {}
+        WrapperData(WrapperError e) : error(e) {}
+    };
+
+    template <>
+    union WrapperData<void> {
+        WrapperError error;
+        WrapperData() {}
+        WrapperData(WrapperError e) : error(e) {}
+    };
+
+    template<typename T>
+    struct WrapperResult {
+        uint8_t discriminant;
+        WrapperData<T> data;
+        WrapperResult(uint8_t d, WrapperData<T> v): discriminant(d), data(v) {}
+        static WrapperResult<T> value(T value) {
+            return WrapperResult(0, WrapperData<T>(value));
+        }
+        static WrapperResult<T> error(WrapperError error) {
+            return WrapperResult(1, WrapperData<T>(error));
+        }
+    };
+
+    template<>
+    struct WrapperResult<void> {
+        uint8_t discriminant;
+        WrapperData<void> data;
+        WrapperResult(uint8_t d, WrapperData<void> v): discriminant(d), data(v) {}
+        static WrapperResult<void> value() {
+            return WrapperResult(0, WrapperData<void>());
+        }
+        static WrapperResult<void> error(WrapperError error) {
+            return WrapperResult(1, WrapperData<void>(error));
+        }
+    };
+
+"#.to_string()
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,0 +1,142 @@
+extern "C" {
+    pub fn jpeg_std_error<'a>(err: &'a mut jpeg_error_mgr) -> *mut jpeg_error_mgr;
+    pub fn jpeg_CreateCompress(cinfo: *mut jpeg_compress_struct, version: c_int, structsize: usize);
+    pub fn jpeg_CreateDecompress(
+        cinfo: *mut jpeg_decompress_struct,
+        version: c_int,
+        structsize: usize,
+    );
+    pub fn jpeg_destroy_compress(cinfo: &mut jpeg_compress_struct);
+    pub fn jpeg_destroy_decompress(cinfo: &mut jpeg_decompress_struct);
+    pub fn jpeg_stdio_dest(cinfo: &mut jpeg_compress_struct, outfile: *mut FILE);
+    pub fn jpeg_stdio_src(cinfo: &mut jpeg_decompress_struct, infile: *mut FILE);
+    pub fn jpeg_mem_dest(
+        cinfo: &mut jpeg_compress_struct,
+        outbuffer: *mut *mut u8,
+        outsize: *mut c_ulong,
+    );
+    pub fn jpeg_mem_src(cinfo: &mut jpeg_decompress_struct, inbuffer: *const u8, insize: c_ulong);
+    pub fn jpeg_set_defaults(cinfo: &mut jpeg_compress_struct);
+    pub fn jpeg_set_colorspace(cinfo: &mut jpeg_compress_struct, colorspace: J_COLOR_SPACE);
+    pub fn jpeg_default_colorspace(cinfo: &mut jpeg_compress_struct);
+    pub fn jpeg_set_quality(
+        cinfo: &mut jpeg_compress_struct,
+        quality: c_int,
+        force_baseline: boolean,
+    );
+    pub fn jpeg_set_linear_quality(
+        cinfo: &mut jpeg_compress_struct,
+        scale_factor: c_int,
+        force_baseline: boolean,
+    );
+    pub fn jpeg_add_quant_table(
+        cinfo: &mut jpeg_compress_struct,
+        which_tbl: c_int,
+        basic_table: *const c_uint,
+        scale_factor: c_int,
+        force_baseline: boolean,
+    );
+    pub fn jpeg_quality_scaling(quality: c_int) -> c_int;
+    pub fn jpeg_float_quality_scaling(quality: f32) -> f32;
+    pub fn jpeg_simple_progression(cinfo: &mut jpeg_compress_struct);
+    pub fn jpeg_suppress_tables(cinfo: &mut jpeg_compress_struct, suppress: boolean);
+    pub fn jpeg_alloc_quant_table(cinfo: &mut jpeg_common_struct) -> *mut JQUANT_TBL;
+    pub fn jpeg_alloc_huff_table(cinfo: &mut jpeg_common_struct) -> *mut JHUFF_TBL;
+    pub fn jpeg_start_compress(cinfo: &mut jpeg_compress_struct, write_all_tables: boolean);
+    pub fn jpeg_write_scanlines(
+        cinfo: &mut jpeg_compress_struct,
+        scanlines: JSAMPARRAY,
+        num_lines: JDIMENSION,
+    ) -> JDIMENSION;
+    pub fn jpeg_finish_compress(cinfo: &mut jpeg_compress_struct);
+    pub fn jpeg_write_raw_data(
+        cinfo: &mut jpeg_compress_struct,
+        data: JSAMPIMAGE,
+        num_lines: JDIMENSION,
+    ) -> JDIMENSION;
+    pub fn jpeg_write_marker(
+        cinfo: &mut jpeg_compress_struct,
+        marker: c_int,
+        dataptr: *const u8,
+        datalen: c_uint,
+    );
+    pub fn jpeg_write_m_header(cinfo: &mut jpeg_compress_struct, marker: c_int, datalen: c_uint);
+    pub fn jpeg_write_m_byte(cinfo: &mut jpeg_compress_struct, val: c_int);
+    pub fn jpeg_write_tables(cinfo: &mut jpeg_compress_struct);
+    pub fn jpeg_read_header(cinfo: &mut jpeg_decompress_struct, require_image: boolean) -> c_int;
+    pub fn jpeg_start_decompress(cinfo: &mut jpeg_decompress_struct) -> boolean;
+    pub fn jpeg_read_scanlines(
+        cinfo: &mut jpeg_decompress_struct,
+        scanlines: JSAMPARRAY_MUT,
+        max_lines: JDIMENSION,
+    ) -> JDIMENSION;
+    pub fn jpeg_finish_decompress(cinfo: &mut jpeg_decompress_struct) -> boolean;
+    pub fn jpeg_read_raw_data(
+        cinfo: &mut jpeg_decompress_struct,
+        data: JSAMPIMAGE_MUT,
+        max_lines: JDIMENSION,
+    ) -> JDIMENSION;
+    pub fn jpeg_has_multiple_scans(cinfo: &mut jpeg_decompress_struct) -> boolean;
+    pub fn jpeg_start_output(cinfo: &mut jpeg_decompress_struct, scan_number: c_int) -> boolean;
+    pub fn jpeg_finish_output(cinfo: &mut jpeg_decompress_struct) -> boolean;
+    pub fn jpeg_input_complete(cinfo: &mut jpeg_decompress_struct) -> boolean;
+    #[deprecated]
+    pub fn jpeg_new_colormap(cinfo: &mut jpeg_decompress_struct);
+    pub fn jpeg_consume_input(cinfo: &mut jpeg_decompress_struct) -> c_int;
+    pub fn jpeg_float_add_quant_table(
+        cinfo: &mut jpeg_compress_struct,
+        which_tbl: c_int,
+        basic_table: *const c_uint,
+        scale_factor: f32,
+        force_baseline: boolean,
+    );
+
+    /// Precalculate JPEG dimensions for current compression parameters
+    pub fn jpeg_save_markers(
+        cinfo: &mut jpeg_decompress_struct,
+        marker_code: c_int,
+        length_limit: c_uint,
+    );
+    pub fn jpeg_set_marker_processor(
+        cinfo: &mut jpeg_decompress_struct,
+        marker_code: c_int,
+        routine: jpeg_marker_parser_method,
+    );
+    pub fn jpeg_read_coefficients(
+        cinfo: &mut jpeg_decompress_struct,
+    ) -> *mut *mut jvirt_barray_control;
+    pub fn jpeg_write_coefficients(
+        cinfo: &mut jpeg_compress_struct,
+        coef_arrays: *mut *mut jvirt_barray_control,
+    );
+    pub fn jpeg_copy_critical_parameters(
+        srcinfo: &mut jpeg_decompress_struct,
+        dstinfo: &mut jpeg_compress_struct,
+    );
+    pub fn jpeg_abort_compress(cinfo: &mut jpeg_compress_struct);
+    pub fn jpeg_abort_decompress(cinfo: &mut jpeg_decompress_struct);
+    pub fn jpeg_resync_to_restart(cinfo: &mut jpeg_decompress_struct, desired: c_int) -> boolean;
+    pub fn jpeg_c_bool_param_supported(
+        cinfo: &mut jpeg_compress_struct,
+        param: J_BOOLEAN_PARAM,
+    ) -> boolean;
+    pub fn jpeg_c_set_bool_param(
+        cinfo: &mut jpeg_compress_struct,
+        param: J_BOOLEAN_PARAM,
+        value: boolean,
+    );
+    pub fn jpeg_c_get_bool_param(cinfo: &mut jpeg_compress_struct, param: J_BOOLEAN_PARAM) -> boolean;
+    pub fn jpeg_c_float_param_supported(
+        cinfo: &mut jpeg_compress_struct,
+        param: J_FLOAT_PARAM,
+    ) -> boolean;
+    pub fn jpeg_c_set_float_param(
+        cinfo: &mut jpeg_compress_struct,
+        param: J_FLOAT_PARAM,
+        value: f32,
+    );
+    pub fn jpeg_c_get_float_param(cinfo: &mut jpeg_compress_struct, param: J_FLOAT_PARAM) -> f32;
+    pub fn jpeg_c_int_param_supported(cinfo: &mut jpeg_compress_struct, param: J_INT_PARAM) -> boolean;
+    pub fn jpeg_c_set_int_param(cinfo: &mut jpeg_compress_struct, param: J_INT_PARAM, value: c_int);
+    pub fn jpeg_c_get_int_param(cinfo: &mut jpeg_compress_struct, param: J_INT_PARAM) -> c_int;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -725,102 +725,25 @@ pub unsafe fn jpeg_create_compress(cinfo: *mut jpeg_compress_struct) {
     jpeg_CreateCompress(cinfo, JPEG_LIB_VERSION, mem::size_of::<jpeg_compress_struct>());
 }
 
-extern "C" {
-    pub fn jpeg_std_error<'a>(err: &'a mut jpeg_error_mgr) -> &'a mut jpeg_error_mgr;
-    pub fn jpeg_CreateCompress(cinfo: *mut jpeg_compress_struct, version: c_int, structsize: usize);
-    pub fn jpeg_CreateDecompress(cinfo: *mut jpeg_decompress_struct, version: c_int, structsize: usize);
-    pub fn jpeg_destroy_compress(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_destroy_decompress(cinfo: &mut jpeg_decompress_struct);
-    pub fn jpeg_stdio_dest(cinfo: &mut jpeg_compress_struct, outfile: *mut FILE);
-    pub fn jpeg_stdio_src(cinfo: &mut jpeg_decompress_struct, infile: *mut FILE);
-    pub fn jpeg_mem_dest(cinfo: &mut jpeg_compress_struct,
-                     outbuffer: *mut *mut u8,
-                     outsize: *mut c_ulong);
-    pub fn jpeg_mem_src(cinfo: &mut jpeg_decompress_struct,
-                    inbuffer: *const u8,
-                    insize: c_ulong);
-    pub fn jpeg_set_defaults(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_set_colorspace(cinfo: &mut jpeg_compress_struct, colorspace: J_COLOR_SPACE);
-    pub fn jpeg_default_colorspace(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_set_quality(cinfo: &mut jpeg_compress_struct, quality: c_int, force_baseline: boolean);
-    pub fn jpeg_set_linear_quality(cinfo: &mut jpeg_compress_struct,
-                               scale_factor: c_int,
-                               force_baseline: boolean);
-    pub fn jpeg_add_quant_table(cinfo: &mut jpeg_compress_struct,
-                            which_tbl: c_int,
-                            basic_table: *const c_uint,
-                            scale_factor: c_int,
-                            force_baseline: boolean);
-    pub fn jpeg_float_add_quant_table(cinfo: &mut jpeg_compress_struct,
-                                  which_tbl: c_int,
-                                  basic_table: *const c_uint,
-                                  scale_factor: f32,
-                                  force_baseline: boolean);
-    pub fn jpeg_quality_scaling(quality: c_int) -> c_int;
-    pub fn jpeg_float_quality_scaling(quality: f32) -> f32;
-    pub fn jpeg_simple_progression(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_suppress_tables(cinfo: &mut jpeg_compress_struct, suppress: boolean);
-    pub fn jpeg_alloc_quant_table(cinfo: &mut jpeg_common_struct) -> *mut JQUANT_TBL;
-    pub fn jpeg_alloc_huff_table(cinfo: &mut jpeg_common_struct) -> *mut JHUFF_TBL;
-    pub fn jpeg_start_compress(cinfo: &mut jpeg_compress_struct, write_all_tables: boolean);
-    pub fn jpeg_write_scanlines(cinfo: &mut jpeg_compress_struct, scanlines: JSAMPARRAY,
-                            num_lines: JDIMENSION) -> JDIMENSION;
-    pub fn jpeg_finish_compress(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_write_raw_data(cinfo: &mut jpeg_compress_struct, data: JSAMPIMAGE,
-                           num_lines: JDIMENSION) -> JDIMENSION;
-    pub fn jpeg_write_marker(cinfo: &mut jpeg_compress_struct, marker: c_int,
-                         dataptr: *const u8, datalen: c_uint);
-    pub fn jpeg_write_m_header(cinfo: &mut jpeg_compress_struct, marker: c_int, datalen: c_uint);
-    pub fn jpeg_write_m_byte(cinfo: &mut jpeg_compress_struct, val: c_int);
-    pub fn jpeg_write_tables(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_read_header(cinfo: &mut jpeg_decompress_struct, require_image: boolean) -> c_int;
-    pub fn jpeg_start_decompress(cinfo: &mut jpeg_decompress_struct) -> boolean;
-    pub fn jpeg_read_scanlines(cinfo: &mut jpeg_decompress_struct, scanlines: JSAMPARRAY_MUT,
-                           max_lines: JDIMENSION) -> JDIMENSION;
-    pub fn jpeg_finish_decompress(cinfo: &mut jpeg_decompress_struct) -> boolean;
-    pub fn jpeg_read_raw_data(cinfo: &mut jpeg_decompress_struct, data: JSAMPIMAGE_MUT,
-                          max_lines: JDIMENSION) -> JDIMENSION;
-    pub fn jpeg_has_multiple_scans(cinfo: &jpeg_decompress_struct) -> boolean;
-    pub fn jpeg_start_output(cinfo: &mut jpeg_decompress_struct, scan_number: c_int) -> boolean;
-    pub fn jpeg_finish_output(cinfo: &mut jpeg_decompress_struct) -> boolean;
-    pub fn jpeg_input_complete(cinfo: &jpeg_decompress_struct) -> boolean;
-    #[deprecated]
-    pub fn jpeg_new_colormap(cinfo: &mut jpeg_decompress_struct);
-    pub fn jpeg_consume_input(cinfo: &mut jpeg_decompress_struct) -> c_int;
-    /// Precalculate JPEG dimensions for current compression parameters
-    #[cfg(feature = "jpeg70_abi")]
-    pub fn jpeg_calc_jpeg_dimensions(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_calc_output_dimensions(cinfo: &mut jpeg_decompress_struct);
-    pub fn jpeg_save_markers(cinfo: &mut jpeg_decompress_struct,
-                         marker_code: c_int,
-                         length_limit: c_uint);
-    pub fn jpeg_set_marker_processor(cinfo: &mut jpeg_decompress_struct,
-                                 marker_code: c_int,
-                                 routine: jpeg_marker_parser_method);
-    pub fn jpeg_read_coefficients(cinfo: &mut jpeg_decompress_struct) -> *mut *mut jvirt_barray_control;
-    pub fn jpeg_write_coefficients(cinfo: &mut jpeg_compress_struct,
-                               coef_arrays: *mut *mut jvirt_barray_control);
-    pub fn jpeg_copy_critical_parameters(srcinfo: &jpeg_decompress_struct,
-                                     dstinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_abort_compress(cinfo: &mut jpeg_compress_struct);
-    pub fn jpeg_abort_decompress(cinfo: &mut jpeg_decompress_struct);
-    pub fn jpeg_resync_to_restart(cinfo: &mut jpeg_decompress_struct, desired: c_int) -> boolean;
-    pub fn jpeg_c_bool_param_supported(cinfo: &jpeg_compress_struct,
-                                   param: J_BOOLEAN_PARAM) -> boolean;
-    pub fn jpeg_c_set_bool_param(cinfo: &mut jpeg_compress_struct,
-                             param: J_BOOLEAN_PARAM, value: boolean);
-    pub fn jpeg_c_get_bool_param(cinfo: &jpeg_compress_struct,
-                             param: J_BOOLEAN_PARAM) -> boolean;
-    pub fn jpeg_c_float_param_supported(cinfo: &jpeg_compress_struct, param: J_FLOAT_PARAM) -> boolean;
-    pub fn jpeg_c_set_float_param(cinfo: &mut jpeg_compress_struct, param: J_FLOAT_PARAM, value: f32);
-    pub fn jpeg_c_get_float_param(cinfo: &jpeg_compress_struct, param: J_FLOAT_PARAM) -> f32;
-    pub fn jpeg_c_int_param_supported(cinfo: &jpeg_compress_struct, param: J_INT_PARAM) -> boolean;
-    pub fn jpeg_c_set_int_param(cinfo: &mut jpeg_compress_struct, param: J_INT_PARAM, value: c_int);
-    pub fn jpeg_c_get_int_param(cinfo: &jpeg_compress_struct, param: J_INT_PARAM) -> c_int;
-    pub fn jpeg_set_idct_method_selector(cinfo: &jpeg_compress_struct, param: *const c_void);
-    #[cfg(test)] fn jsimd_can_rgb_ycc() -> c_int;
-    #[cfg(test)] #[allow(dead_code)] fn jsimd_can_fdct_ifast() -> c_int;
-    #[cfg(test)] #[allow(dead_code)] fn jsimd_fdct_ifast(block: *mut DCTELEM);
+include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct WrapperError {
+    buf: *mut u8, len: usize, cap: usize
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+union WrapperData<T: Copy> {
+    value: T,
+    error: WrapperError,
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct WrapperResult<T: Copy> {
+    discriminant: u8,
+    value: WrapperData<T>
 }
 
 #[test]
@@ -867,7 +790,7 @@ pub fn try_compress() {
         jpeg_std_error(&mut err);
         let mut cinfo: jpeg_compress_struct = mem::zeroed();
         cinfo.common.err = &mut err;
-        if 0 == jpeg_c_bool_param_supported(&cinfo, JBOOLEAN_TRELLIS_QUANT) {
+        if 0 == jpeg_c_bool_param_supported(&mut cinfo, JBOOLEAN_TRELLIS_QUANT) {
             panic!("Not linked to mozjpeg?");
         }
         jpeg_create_compress(&mut cinfo);
@@ -1545,4 +1468,31 @@ fn bindgen_test_layout_jpeg_memory_mgr() {
         48usize,
         concat!("Offset of field: ", stringify!(jpeg_memory_mgr), "::", stringify!(max_alloc_chunk))
     );
+}
+
+extern "C" {
+    #[cfg(test)]
+    fn jsimd_can_rgb_ycc() -> c_int;
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn jsimd_can_fdct_ifast() -> c_int;
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn jsimd_fdct_ifast(block: *mut DCTELEM);
+    pub fn jpeg_float_add_quant_table(
+        cinfo: &mut jpeg_compress_struct,
+        which_tbl: c_int,
+        basic_table: *const c_uint,
+        scale_factor: f32,
+        force_baseline: boolean,
+    );
+
+    /// Precalculate JPEG dimensions for current compression parameters
+    #[cfg(feature = "jpeg70_abi")]
+    pub fn jpeg_calc_jpeg_dimensions(cinfo: &mut jpeg_compress_struct);
+
+    // FIXME: wrong type (should be decompress struct, not compress),
+    // second argument is also incorrect.
+    pub fn jpeg_set_idct_method_selector(cinfo: &mut jpeg_compress_struct, param: *const c_void);
+
 }


### PR DESCRIPTION
This shows how to auto-generate wrappers to avoid UB. You can cut all of the parsing boiler-plate by using the `syn` crate, but I don't know if that's acceptable for you. Either way, rolling your own parser isn't hard. 

You can probably cut most of the boilerplate for mapping Rust function signatures to C by using rust-bindgen, ctest or similar (all these crates do this). I just c&p some ctest code and glued it a bit.

Some of the `extern "C" { ... }` declarations are subtly incorrect, which if you want to keep that way will need manual workarounds somewhere. If this crate were a 1:1 FFI wrapper of `mozjpeg`, validated with something like `ctest`, generating the wrappers would require less manual workarounds. 

The approach here uses C++ exceptions in the C code to unwind, translating those back to Rust panics at the FFI boundary. In the non-error path, I couldn't measure any difference when running the reencode example. As long as nothing throws, rust panics and C++ exceptions are free.

In the exceptional path, catching the C++ exception and re-throwing a Rust one does more work than just letting an exception escape. Throwing exceptions / panics is super slow anyways, and if the performance for the error path were to matter, you can adapt this to do something else (e.g. longjmp in C, panic in Rust), or just longjmp in C, and error code in Rust). Error codes and longjmp trade a bit of performance in the non-error path for much better performance in the error-path.

Needless to say, I hacked this in a couple of hours. The intent is only to show how this can be done an automated. One could probably move all of the code generation stuff into a different library, that similar projects could use.

Also, this doesn't show the changes that need to happen in mozjpeg-rust, but in a nutshell instead of panicking in the error handler, you just need to call a C++ function, passing it the error handler as a callback. Then in C++, you call the callback to generate a Rust String, store it in a `mozjpeg_rust_exception` by putting it in a `WrapperError` first, and just throw the exception. That will unwinding through all the C / C++ code until the mozjpeg-sys wrapper that catches the exception.