### PR TITLE
Don't import nasm-rs with the 'parallel' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ libc = "0.2.98"
 [features]
 default = ["nasm_simd"]
 with_simd = [] # nasm is required for x86, but not ARM
-nasm_simd = ["with_simd", "nasm-rs", "nasm-rs/parallel"]
+nasm_simd = ["with_simd", "nasm-rs"]
 unwinding = []
 arith_dec = []
 arith_enc = []


### PR DESCRIPTION
After doing some tests on my Intel i7-8550U CPU the nasm-rs `parallel` feature doesn't seem worth it, in fact it makes the crate slower to compile.

I tried doing a clean release build both with the feature enabled and with it disabled and here are my results:

| Parallel feature | Number of compiled dependencies | Total compile time |
| -------------------- | ---------------------------------------------- | ------------------------ |
| On                     | 35                                                    | 12 seconds           |
| Off                     | 12                                                    | 7 seconds             |

